### PR TITLE
Fix README in erc20 foundry example

### DIFF
--- a/simple-erc20-foundry/README.md
+++ b/simple-erc20-foundry/README.md
@@ -24,8 +24,10 @@ foundryup
 Run command
 
 ```sh
-git clone https://github.com/sukanyaparashar/simple-erc20-foundry.git
+git clone https://github.com/neonlabsorg/examples.git
 ```
+
+**NOTE** All the next operations must be performed from the **examples/simple-erc20-foundry** directory
 
 ## Setup Neon account (using Metamask)
 


### PR DESCRIPTION
This PR changes the cloning repository link in the README.